### PR TITLE
Replace with call to SelectPriority to support PriorityAsString

### DIFF
--- a/html/Ticket/Elements/QuickUpdate
+++ b/html/Ticket/Elements/QuickUpdate
@@ -56,7 +56,7 @@
   </tr>
   <tr>
       <td class="label"><&|/l&>Priority</&>:</td>
-      <td class="value"><input name="Priority" value="<%$Ticket->Priority|h%>" size="5" /></td>
+      <td class="value"><& /Elements/SelectPriority, Name => "Priority", Default => $ARGS{Priority} &> </td>
     </tr>
   <tr>
   <td class="label">


### PR DESCRIPTION
I've updated html/Ticket/Elements/QuickUpdate to call SelectPriority so the extension supports PriorityAsString and it's working, however there is a minor display issue.  Under "The Basics" when displaying the ticket the Priority is displayed as "Priority: Medium/Medium" instead of "Priority: Medium", and when PriorityAsString is disabled it's displayed as "Priority: 0/".

I've been staring at this a bit and really don't know enough about RT's internals to fix it. I'm sure it's trivial and I'm hopeful that someone at Best Practical can fix the in a second or two. 

http://www.gossamer-threads.com/lists/rt/users/116557
